### PR TITLE
Fixes #21 proxy blocking the cli

### DIFF
--- a/bin/quasar-init
+++ b/bin/quasar-init
@@ -4,7 +4,7 @@ var
   command = require('commander'),
   uid = require('uid'),
   ora = require('ora'),
-  download = require('download-github-repo'),
+  download = require('download-git-repo'),
   log = require('../lib/log'),
   qfs = require('../lib/qfs'),
   spinner

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "browser-sync": "^2.13.0",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
-    "download-github-repo": "^0.1.3",
+    "download-git-repo": "^0.2.1",
     "eslint": "^3.9.1",
     "find-root": "^1.0.0",
     "fs-extra": "^1.0.0",


### PR DESCRIPTION
All that was needed to be done was change the `download-github-repo` to `download-git-repo`. 

npm must be setup to use a proxy, for the cli to work. 

```
npm config set proxy http://proxy.company.com:8080
npm config set https-proxy http://proxy.company.com:8080
```

Where `proxy.company.com:8080` is the proxy's address.

Scott