### PR TITLE
Add port option for quasar-serve

### DIFF
--- a/bin/quasar-serve
+++ b/bin/quasar-serve
@@ -8,6 +8,7 @@ var
 
 command
   .usage('[folder]')
+  .option('-p, --port <n>', 'port for asset serving', parseInt)
   .on('--help', function () {
     log('  Examples:')
     log()
@@ -16,21 +17,23 @@ command
     log()
     log('    # serve specific folder'.gray)
     log('    $ quasar serve ./dist')
-    log('    $ quasar serve /work/quasar-app/dist')
+    log('    $ quasar serve /work/quasar-app/dist --port 5050')
+  })
+  .action(function(commandDir, options){
+      var folder = commandDir || process.cwd()
+      var port = options.port || 3000
+      server.create().init({
+          port: port,
+          open: false,
+          reloadOnRestart: true,
+          ghostMode: false,
+          server: {
+              baseDir: folder
+          }
+      })
+
+      watch(folder + '/**/*', function () {
+          server.reload()
+      })
   })
   .parse(process.argv)
-
-var folder = command.args[0] || process.cwd() // eslint-disable-line one-var
-
-server.create().init({
-  open: false,
-  reloadOnRestart: true,
-  ghostMode: false,
-  server: {
-    baseDir: folder
-  }
-})
-
-watch(folder + '/**/*', function () {
-  server.reload()
-})


### PR DESCRIPTION
This adds the option to specify what port assets should be served on with `quasar-serve`, e.g. `quasar serve ./dist --port 5050`. It defaults to port 3000.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on Windows
- [x] It's been tested on Linux
- [ ] It's been tested on MacOS

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
