### PR TITLE
fix: unable to create symlink without privileges on Windows

### DIFF
--- a/lib/qfs.js
+++ b/lib/qfs.js
@@ -55,7 +55,7 @@ function move (src, dest) {
 }
 
 function symlink (dest, src) {
-  return fs.symlinkSync(dest, src)
+  return fs.symlinkSync(dest, src, 'junction')
 }
 
 function join () {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on Windows
- [ ] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Using the same syntax for fs.symlink as in 'npm link' command. This creates a 'junction' instead of a symlink on Windows, which can be created without privileges. Cordova workflow tested on Windows, other platforms shouldn't be effected but were not tested.

[npm source](https://github.com/npm/npm/blob/latest/lib/utils/link.js#L69)