### PR TITLE
Fix "quasar help" message

### DIFF
--- a/bin/quasar
+++ b/bin/quasar
@@ -35,7 +35,7 @@ commander
   .command('clean', 'clean production build artifacts')
   .command('test', 'run unit and/or e2e tests')
   .command('lint', 'lint source code')
-  .command('wrap [type]', 'wrap app (currently only with "cordova" type)')
+  .command('wrap [type]', 'wrap app with "cordova" or "electron"')
   .command('serve [folder]', 'create live reload static-content server')
   .command('version', 'output CLI and current app Quasar version')
   .parse(process.argv)


### PR DESCRIPTION
Missing `electron` type in help message for `quasar wrap` command

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on Windows
- [ ] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
