### PR TITLE
Generate package.json only with electron specific dependencies only

### DIFF
--- a/lib/build/webpack-electron-config.js
+++ b/lib/build/webpack-electron-config.js
@@ -87,6 +87,7 @@ module.exports = function (cfg) {
         compiler.plugin('emit', (compilation, callback) => {
           const pkg = require(appPaths.resolve.app('package.json'))
 
+          pkg.dependencies = cfg.electron.dependencies || pkg.dependencies
           pkg.main = './electron-main.js'
           const source = JSON.stringify(pkg)
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on Windows
- [ ] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Currently electron packager uses project package.json and includes all packages when building electron app - this includes unnecessary packages to electron main process. This PR allows to only include electron-specific packages, by defining them quasar.conf.js.