### PR TITLE
Use yarn instead of npm

### DIFF
--- a/bin/quasar-init
+++ b/bin/quasar-init
@@ -83,7 +83,7 @@ try {
 catch (err) {
   console.log(err)
   warn(`Package vue-cli not installed globally.`)
-  warn('Run "npm i -g vue-cli" to install Vue CLI and then try again.')
+  warn('Run "npm i -g vue-cli" or "npm i -g @vue/cli @vue/cli-init" to install Vue CLI and then try again.')
   warn()
   process.exit(1)
 }

--- a/lib/electron/index.js
+++ b/lib/electron/index.js
@@ -94,15 +94,14 @@ class ElectronRunner {
     }).then(() => {
       return new Promise((resolve, reject) => {
         spawn(
-          'npm',
+          'yarn',
           [
-            'install',
             '--production'
           ],
           appPaths.resolve.app(cfg.build.distDir),
           code => {
             if (code) {
-              warn(`[FAIL] NPM failed installing dependencies`)
+              warn(`[FAIL] YARN failed installing dependencies`)
               process.exit(1)
             }
             resolve()

--- a/lib/mode/mode-electron.js
+++ b/lib/mode/mode-electron.js
@@ -29,8 +29,8 @@ class Mode {
 
     log(`Installing Electron dependencies...`)
     spawn.sync(
-      'npm',
-      ['install', '--save-dev', '--save-exact'].concat(Object.keys(electronDeps).map(dep => {
+      'yarn',
+      ['add', '--dev', '--exact'].concat(Object.keys(electronDeps).map(dep => {
         return `${dep}@${electronDeps[dep]}`
       })),
       appPaths.appDir,
@@ -53,8 +53,8 @@ class Mode {
 
     log(`Uninstalling Electron dependencies...`)
     spawn.sync(
-      'npm',
-      ['uninstall', '--save-dev'].concat(Object.keys(electronDeps)),
+      'yarn',
+      ['remove', '--dev'].concat(Object.keys(electronDeps)),
       appPaths.appDir,
       () => warn('Failed to uninstall Electron dependencies')
     )


### PR DESCRIPTION
It just replaces npm usage with yarn for local packages.
It still needs a switch whether to use yarn or npm based on the presence of yarn.lock or based on the option selected on project init.