### PR TITLE
Log error when quasar config prep fails

### DIFF
--- a/bin/quasar-build
+++ b/bin/quasar-build
@@ -84,6 +84,7 @@ try {
 }
 catch (e) {
   warn(`[FAIL] quasar.conf.js has JS errors`)
+  warn(e.stack || e)
   process.exit(1)
 }
 

--- a/bin/quasar-build
+++ b/bin/quasar-build
@@ -83,8 +83,8 @@ try {
   quasarConfig.prepare()
 }
 catch (e) {
+  console.log(e)
   warn(`[FAIL] quasar.conf.js has JS errors`)
-  warn(e.stack || e)
   process.exit(1)
 }
 

--- a/bin/quasar-dev
+++ b/bin/quasar-dev
@@ -146,8 +146,8 @@ async function goLive () {
     await quasarConfig.prepare()
   }
   catch (e) {
+    console.log(e)
     warn(`[FAIL] quasar.conf.js has JS errors`)
-    warn(e.stack || e)
     process.exit(1)
   }
 

--- a/bin/quasar-dev
+++ b/bin/quasar-dev
@@ -147,6 +147,7 @@ async function goLive () {
   }
   catch (e) {
     warn(`[FAIL] quasar.conf.js has JS errors`)
+    warn(e.stack || e)
     process.exit(1)
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on Windows
- [ ] It's been tested on Linux
- [x] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
When a quasar.conf.js contains JS errors, the build tool logs a vague message '[FAIL] quasar.conf.js has JS errors' without any specific details. This change logs out the error stack after the fail message.
