### PR TITLE
Use wait instead of timeout.

### DIFF
--- a/lib/helpers/notifier.js
+++ b/lib/helpers/notifier.js
@@ -15,7 +15,7 @@ module.exports = function ({ title = 'Quasar App', message = '', subtitle = '', 
     message,
     subtitle,
     icon,
-    wait: hasClick ? true : false,
+    wait: hasClick,
     actions: 'Close'
   }, (err, response, metadata) => {
     if (

--- a/lib/helpers/notifier.js
+++ b/lib/helpers/notifier.js
@@ -15,7 +15,7 @@ module.exports = function ({ title = 'Quasar App', message = '', subtitle = '', 
     message,
     subtitle,
     icon,
-    timeout: hasClick ? 10 : undefined,
+    wait: hasClick ? true : false,
     actions: 'Close'
   }, (err, response, metadata) => {
     if (


### PR DESCRIPTION
Addresses issue #97 see my comment here: 
https://github.com/quasarframework/quasar-cli/issues/97#issuecomment-380790806

Basically it removes "undefined" timeout possibility and uses wait default of 5 seconds, which is more than enough.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on Windows
- [ ] It's been tested on Linux
- [X] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
