### PR TITLE
Add support for --target/--arch options for "electron-builder" bundler (#125)

### DIFF
--- a/bin/quasar-build
+++ b/bin/quasar-build
@@ -39,17 +39,21 @@ if (argv.help) {
       --target, -T   App target
                        - Cordova (default: all installed)
                           [android|ios|blackberry10|browser|osx|ubuntu|webos|windows]
-                       - Electron with "electron-packager" bundler (default: yours)
+                       - Electron with default "electron-packager" bundler (default: yours)
                           [darwin|win32|linux|mas|all]
+                       - Electron with "electron-builder" bundler (default: yours)
+                          [darwin|mac|win32|win|linux|all]
       --debug, -d    Build for debugging purposes
       --help, -h     Displays this message
 
       ONLY for Electron mode:
       --bundler, -b  Bundler (electron-packager or electron-builder)
                        [packager|builder]
-      ONLY for Electron mode with default "electron-packager" bundler:
       --arch, -A     App architecture (default: yours)
-                       [ia32|x64|armv7l|arm64|mips64el|all]
+                       - with default "electron-packager" bundler:
+                           [ia32|x64|armv7l|arm64|mips64el|all]
+                       - with "electron-builder" bundler:
+                           [ia32|x64|armv7l|arm64|all]
   `)
   process.exit(0)
 }

--- a/lib/electron/index.js
+++ b/lib/electron/index.js
@@ -141,7 +141,7 @@ class ElectronRunner {
 
         const bundlePromise = bundlerName === 'packager'
           ? bundler(bundlerConfig)
-          : bundler.build({ config: bundlerConfig })
+          : bundler.build(bundlerConfig)
 
         bundlePromise
           .then(() => {

--- a/lib/quasar-config.js
+++ b/lib/quasar-config.js
@@ -566,6 +566,12 @@ class QuasarConfig {
           }
         }
         else {
+          cfg.electron.builder = {
+            platform: cfg.ctx.targetName,
+            arch: cfg.ctx.archName,
+            config: cfg.electron.builder
+          }
+
           bundler.ensureBuilderCompatibility()
         }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on Windows
- [x] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This patch introduces support to `--target` and `--arch` options when building Electron apps with "electron-builder" bundler, making it suitable for cross-platform builds in a CI environment. Their meaning is the same as of "electron-packager" bundler, but the supported values are slightly different:
* Arch value `mips64el` is not supported
* Target platform value `mas` is not supported
* Target platform value `win` is supported as a synonym of `win32`
* Target platform value `mac` is supported as a synonym of `darwin`

Fixes #125