### PR TITLE
Add SW push/sync feature in dev mode

### DIFF
--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -65,7 +65,20 @@ class DevServer {
         this.server.use(function (req, res, next) {
           if (req.url === '/service-worker.js') {
             res.setHeader('Content-Type', 'text/javascript')
-            res.send(resetScript)
+            if (cfg.pwa.swPlugins && cfg.pwa.swPlugins.push) {
+              res.write(fs.readFileSync(
+                path.join(appPaths.pwaDir, cfg.pwa.swPlugins.push),
+                'utf-8'
+              ))
+            }
+            if (cfg.pwa.swPlugins && cfg.pwa.swPlugins.sync) {
+              res.write(fs.readFileSync(
+                path.join(appPaths.pwaDir, cfg.pwa.swPlugins.sync),
+                'utf-8'
+              ))
+            }
+            res.write(resetScript)
+            res.end()
           }
           else {
             next()

--- a/lib/quasar-config.js
+++ b/lib/quasar-config.js
@@ -412,6 +412,10 @@ class QuasarConfig {
       cfg.pwa = merge({
         workboxPluginMode: 'GenerateSW',
         workboxOptions: {},
+        swPlugins: {
+          push: 'push-service-worker.js',
+          sync: 'sync-service-worker.js'
+        },
         manifest: {
           name: this.pkg.productName || this.pkg.name || 'Quasar App',
           short_name: this.pkg.name || 'quasar-pwa',

--- a/templates/pwa/push-service-worker.js
+++ b/templates/pwa/push-service-worker.js
@@ -1,0 +1,29 @@
+/*
+ * This file (which will be part of your service worker)
+ * is picked up by the build system and appended at the end of the service-worker
+ * To do so, You must active this option in
+ * quasar.conf > pwa > swPlugins > push by setting the name of this file
+ * THIS PART OF THE CODE is OUT of Hot Reload managment : You should refresh page to reload it.
+ */
+
+/**
+ * Start listening for web notification (client part), and will display them to the user.
+ * Fill free to add/remove anypart of the code
+ */
+self.addEventListener('push', function (event) {
+  if (!event.data) {
+    console.error('This push event has no data.', event)
+    return
+  }
+
+  let msg
+  try {
+    msg = event.data.json()
+  } catch (e) {
+    console.error('This push event data is not valid JSON.', event.data)
+    return
+  }
+  // Sending message to the service-worker for display
+  const promiseChain = self.registration.showNotification(msg.title, msg.options)
+  event.waitUntil(promiseChain)
+})

--- a/templates/pwa/sync-service-worker.js
+++ b/templates/pwa/sync-service-worker.js
@@ -1,0 +1,11 @@
+/*
+ * This file (which will be part of your service worker)
+ * is picked up by the build system and appended at the end of the service-worker
+ * To do so, You must active this option in
+ * quasar.conf > pwa > swPlugins > sync by setting the name of this file
+ * THIS PART OF THE CODE is OUT of Hot Reload managment : You should refresh page to reload it.
+ */
+
+self.addEventListener('sync', function (event) {
+  // Implement your 'sync' event managment.
+})


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on Windows
- [x] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The PR extends the Quasar-cli behaviour in Dev mode : It make it able to deliver the no-op service worker, but also a push and a sync part of code for managing this events.