### PR TITLE
fix: #197 Webpack does not load nested dependencies

### DIFF
--- a/lib/webpack/create-chain.js
+++ b/lib/webpack/create-chain.js
@@ -16,6 +16,7 @@ module.exports = function (cfg, configName) {
     fileHash = needsHash ? '.[hash:8]' : '',
     chunkHash = needsHash ? '.[contenthash:8]' : '',
     resolveModules = [
+      'node_modules',
       appPaths.resolve.app('node_modules'),
       appPaths.resolve.cli('node_modules')
     ]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on Windows
- [ ] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Fixes an issue where Webpack was not loading dependencies that were nested inside package's node_modules reported in #197 

**Details:**
When two packages share a common package, but with different versions, one of the packages gets a nested `node_modules` holding the required version of the package it depends on.

The lack of `node_modules` string means that Webpack will only do a shallow look for packages inside the specified absolute paths.

The change is tested locally and is checked against resources like the Vue CLI, where they do the same. 
